### PR TITLE
Abc530 jpng

### DIFF
--- a/data_ingestion/metadata_occurrences.json
+++ b/data_ingestion/metadata_occurrences.json
@@ -37,7 +37,25 @@
       "name": "limit",
       "label": "Occurrence Limit per Species",
       "helpText": "Maximum number of GBIF occurrences per taxon (max 300)",
-      "defaultValue": "150"
+      "defaultValue": "300"
+    },
+    {
+      "name": "sleep_seconds",
+      "label": "Seconds to Sleep Before Each GBIF Request",
+      "helpText": "Seconds to sleep before each GBIF request. This is to avoid hitting the API rate limit.",
+      "defaultValue": "0.25"
+    },
+    {
+      "name": "retry_delay_seconds",
+      "label": "Retry delay seconds after a failed GBIF request",
+      "helpText": "Maximum seconds to wait before retrying a failed GBIF request. This is to avoid hitting the API rate limit.",
+      "defaultValue": "1.5"
+    },
+    {
+      "name": "max_retries",
+      "label": "Number of retries after the first failed GBIF request",
+      "helpText": "Maximum number of retries after the first failed GBIF request. This is to avoid hitting the API rate limit.",
+      "defaultValue": "1"
     }
   ]
 }

--- a/data_ingestion/src/dependencies/occurrences_launcher.py
+++ b/data_ingestion/src/dependencies/occurrences_launcher.py
@@ -10,7 +10,12 @@ def run(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("--validated_input", required=True, help="Path to validated taxonomy JSONL file")
     parser.add_argument("--output_dir", required=True, help="Directory to store occurrence files")
-    parser.add_argument("--limit", type=int, default=150, help="Number of GBIF occurrences per species. Max. 300")
+    parser.add_argument("--limit", type=int, default=300, help="Number of GBIF occurrences per species. Max. 300")
+
+    parser.add_argument("--sleep_seconds", type=float, default=0.25, help="Delay before each GBIF request")
+    parser.add_argument( "--retry_delay_seconds", type=float, default=1.5, help="Delay before retrying a failed GBIF request")
+    parser.add_argument( "--max_retries", type=int, default=1, help="Number of retries after the first failed GBIF request")
+
 
     args, beam_args = parser.parse_known_args(argv)
     occurrences_pipeline(args, beam_args)

--- a/data_ingestion/src/dependencies/occurrences_pipeline.py
+++ b/data_ingestion/src/dependencies/occurrences_pipeline.py
@@ -6,6 +6,7 @@ from apache_beam.options.pipeline_options import PipelineOptions, SetupOptions
 from dependencies.utils.transforms import WriteSpeciesOccurrencesFn
 
 
+
 def occurrences_pipeline(args, beam_args):
     pipeline_options = PipelineOptions(beam_args)
     pipeline_options.view_as(SetupOptions).save_main_session = True
@@ -18,11 +19,14 @@ def occurrences_pipeline(args, beam_args):
         )
 
         results = (
-            records
-            | "FetchAndWriteOccurrences" >> beam.ParDo(
-                WriteSpeciesOccurrencesFn(
-                    output_dir=args.output_dir,
-                    max_records=args.limit
+                records
+                | "FetchAndWriteOccurrences" >> beam.ParDo(
+                    WriteSpeciesOccurrencesFn(
+                        output_dir=args.output_dir,
+                        max_records=args.limit,
+                        sleep_seconds=args.sleep_seconds,
+                        retry_delay_seconds=args.retry_delay_seconds,
+                        max_retries=args.max_retries,
                 )
             ).with_outputs("dead", main="success")
         )
@@ -90,6 +94,10 @@ if __name__ == "__main__":
     parser.add_argument("--validated_input", required=True, help="Path to validated taxonomy JSONL file")
     parser.add_argument("--output_dir", required=True, help="Directory to store occurrence files")
     parser.add_argument("--limit", type=int, default=150, help="Max GBIF occurrences per species")
+
+    parser.add_argument("--sleep_seconds", type=float, default=0.25, help="Delay before each GBIF request")
+    parser.add_argument( "--retry_delay_seconds", type=float, default=1.5, help="Delay before retrying a failed GBIF request")
+    parser.add_argument( "--max_retries", type=int, default=1, help="Number of retries after the first failed GBIF request")
 
     args, beam_args = parser.parse_known_args()
     occurrences_pipeline(args, beam_args)

--- a/data_ingestion/src/dependencies/utils/bq_gbif_occurrences_schema.json
+++ b/data_ingestion/src/dependencies/utils/bq_gbif_occurrences_schema.json
@@ -61,6 +61,6 @@
   { "name": "institutionCode", "type": "STRING", "mode": "NULLABLE" },
   { "name": "collectionCode", "type": "STRING", "mode": "NULLABLE" },
   { "name": "catalogNumber", "type": "STRING", "mode": "NULLABLE" },
-  { "name": "licence", "type": "STRING", "mode": "NULLABLE" },
+  { "name": "license", "type": "STRING", "mode": "NULLABLE" },
   { "name": "iucnRedListCategory", "type": "STRING", "mode": "NULLABLE" }
 ]

--- a/data_ingestion/src/dependencies/utils/transforms.py
+++ b/data_ingestion/src/dependencies/utils/transforms.py
@@ -18,6 +18,7 @@ from shapely import wkt
 from shapely.geometry import Point, MultiPoint
 from shapely.ops import transform
 from rasterio.mask import mask
+from requests.exceptions import RequestException
 from typing import Any, Dict, Iterable, List, Optional
 from dependencies.utils.helpers import sanitize_species_name, fetch_spatial_file_to_local, extract_species_name
 
@@ -215,14 +216,31 @@ class WriteSpeciesOccurrencesFn(DoFn):
     Fetch GBIF occurrences for one validated species, write them to a JSONL file,
     and emit one success status record on the main output.
 
+    Throttling:
+      - sleep once before each GBIF request
+
+    Retry policy:
+      - one retry after the first failed request
+      - fixed delay between attempts
+
     On failure, emit a tagged "dead" record.
     """
 
     DEAD = "dead"
 
-    def __init__(self, output_dir, max_records=150):
+    def __init__(
+        self,
+        output_dir: str,
+        max_records: int = 150,
+        sleep_seconds: float = 0.25,
+        retry_delay_seconds: float = 1.5,
+        max_retries: int = 1,
+    ):
         self.output_dir = output_dir
         self.max_records = max_records
+        self.sleep_seconds = sleep_seconds
+        self.retry_delay_seconds = retry_delay_seconds
+        self.max_retries = max_retries
 
         self.species_processed = Metrics.counter(
             self.__class__, "species_processed"
@@ -236,9 +254,34 @@ class WriteSpeciesOccurrencesFn(DoFn):
         self.species_failed = Metrics.counter(
             self.__class__, "species_failed"
         )
+        self.gbif_retries = Metrics.counter(
+            self.__class__, "gbif_retries"
+        )
 
     def setup(self):
         self.gbif_client = gbif_occ
+
+    def _search_with_retry(self, *, usage_key: int):
+        attempts = self.max_retries + 1
+
+        for attempt in range(attempts):
+            try:
+                return self.gbif_client.search(
+                    taxonKey=usage_key,
+                    basisOfRecord=["PRESERVED_SPECIMEN", "MATERIAL_SAMPLE"],
+                    occurrenceStatus="PRESENT",
+                    hasCoordinate=True,
+                    hasGeospatialIssue=False,
+                    limit=self.max_records,
+                )
+            except RequestException:
+                if attempt < attempts - 1:
+                    self.gbif_retries.inc()
+                    time.sleep(self.retry_delay_seconds)
+                else:
+                    raise
+
+        raise RuntimeError("Unreachable: retry loop exited without return or exception")
 
     def process(self, record):
         species = record.get("scientificName")
@@ -252,15 +295,10 @@ class WriteSpeciesOccurrencesFn(DoFn):
         tmp_path = f"{out_path}.tmp"
 
         try:
-            resp = self.gbif_client.search(
-                taxonKey=usage_key,
-                basisOfRecord=["PRESERVED_SPECIMEN", "MATERIAL_SAMPLE"],
-                occurrenceStatus="PRESENT",
-                hasCoordinate=True,
-                hasGeospatialIssue=False,
-                limit=self.max_records,
-            )
+            if self.sleep_seconds:
+                time.sleep(self.sleep_seconds)
 
+            resp = self._search_with_retry(usage_key=usage_key)
             occurrences = resp.get("results", [])
 
             with FileSystems.create(tmp_path) as f:
@@ -280,13 +318,13 @@ class WriteSpeciesOccurrencesFn(DoFn):
                         "countryCode": occ.get("countryCode"),
                         "gadm": occ.get("gadm"),
                         "basisOfRecord": occ.get("basisOfRecord"),
-                        'datasetKey': occ.get('datasetKey'),
+                        "datasetKey": occ.get("datasetKey"),
                         "occurrenceID": occ.get("occurrenceID"),
                         "gbifID": occ.get("gbifID"),
                         "institutionCode": occ.get("institutionCode"),
                         "collectionCode": occ.get("collectionCode"),
                         "catalogNumber": occ.get("catalogNumber"),
-                        'licence': occ.get('licence'),
+                        "license": occ.get("license"),
                         "iucnRedListCategory": occ.get("iucnRedListCategory"),
                     }
                     f.write((json.dumps(occ_out) + "\n").encode("utf-8"))


### PR DESCRIPTION
The occurrence pipeline has been updated to manage throttling of GBIF API calls.

Added controlled throttling and retry logic to the GBIF occurrence retrieval step by extending WriteSpeciesOccurrencesFn. Each API call now includes a configurable delay (sleep_seconds) and a single retry with fixed backoff (retry_delay_seconds, max_retries).

The Dataflow Flex template has been updated to include these new parameters, as well as the occurrence pipeline template launcher. 

The SDK Docker image has also been updated to reflect these changes. 